### PR TITLE
API improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbts",
-  "version": "1.7.2",
+  "version": "1.8.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/commands/active/event.ts
+++ b/src/commands/active/event.ts
@@ -151,7 +151,7 @@ const run = async (args?: I_Event) => {
             break;
         }
         case "ongoing":{
-            const event = await ActiveEventService.getActiveEvent();
+            const event = await ActiveEventService.getOngoingActiveEvent();
 
             eventRes = {
                 content: `found ${event.length} ongoing events`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export {ownerID, prefixes, guildIDs, trustedID} from "./assets/configs/config.js
 /**
  * current bot version
  */
-export const botVersion = "1.7.2";
+export const botVersion = "1.8.1";
 
 // still string | undefined so i put null coalescing
 export const DISCORD_TOKEN = process.env.DISCORD_TOKEN ?? "";
@@ -46,6 +46,8 @@ export const SESSION_SECRET = process.env.SESSION_SECRET ?? "";
 
 export const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
 export const SUPABASE_KEY = process.env.SUPABASE_KEY ?? "";
+
+export const CORS_ORIGIN= process.env.CORS_ORIGIN ?? "";
 
 // FROM HERE IS THE CHECKING FOR .env
 
@@ -76,6 +78,11 @@ if(SUPABASE_URL === "" || SUPABASE_KEY === "") {
     console.warn("Warning: Couldn't find SUPABASE DATABASE credentials in .env");
     console.warn("Warning: database feature will be disabled");
 }
+
+// checking for CORS in .env
+if(MODE === "production")
+    if(CORS_ORIGIN === "")
+        throw new Error("Couldn't find CORS_ORIGIN in .env");
 
 
 // muted variable to share across all modules

--- a/src/models/DiscordUser.ts
+++ b/src/models/DiscordUser.ts
@@ -1,0 +1,44 @@
+export interface DiscordUser {
+    id:                   string;
+    system:               boolean;
+    username:             string;
+    globalName:           null;
+    discriminator:        string;
+    avatar:               string;
+    avatarDecoration:     null;
+    avatarDecorationData: null;
+    createdTimestamp:     number;
+    defaultAvatarURL:     string;
+    avatarURL:            string;
+    displayAvatarURL:     string;
+}
+
+export function isDiscordUser(obj: unknown): obj is DiscordUser {
+    if (typeof obj !== "object" || obj === null) return false;
+
+    if (!("id" in obj) || typeof obj.id !== "string") return false;
+
+    if (!("system" in obj) || typeof obj.system !== "boolean") return false;
+
+    if (!("username" in obj) || typeof obj.username !== "string") return false;
+
+    if (!("globalName" in obj) || obj.globalName !== null) return false;
+
+    if (!("discriminator" in obj) || typeof obj.discriminator !== "string") return false;
+
+    if (!("avatar" in obj) || typeof obj.avatar !== "string") return false;
+
+    if (!("avatarDecoration" in obj) || obj.avatarDecoration !== null) return false;
+
+    if (!("avatarDecorationData" in obj) || obj.avatarDecorationData !== null) return false;
+
+    if (!("createdTimestamp" in obj) || typeof obj.createdTimestamp !== "number") return false;
+
+    if (!("defaultAvatarURL" in obj) || typeof obj.defaultAvatarURL !== "string") return false;
+
+    if (!("avatarURL" in obj) || typeof obj.avatarURL !== "string") return false;
+
+    if (!("displayAvatarURL" in obj) || typeof obj.displayAvatarURL !== "string") return false;
+
+    return true;
+}

--- a/src/models/SessionView.ts
+++ b/src/models/SessionView.ts
@@ -1,6 +1,7 @@
 import { isUser, isUserWithoutId, User } from "./User";
 
-export interface SessionView extends Omit<User, "id">{
+// using type union to prevent duck typing
+export type SessionView = Omit<User, "id"> & {
     id: string;
     user_id: string;
     ends_at: string;

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -7,10 +7,15 @@ import cors from "cors";
 
 import routes from "./routes";
 import { sessionCheck, page404 } from "./middlewares";
+import { CORS_ORIGIN } from "@config";
 
 const express = Express();
 
-express.use(cors());
+express.use(cors({
+    origin: CORS_ORIGIN,
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    credentials: true
+}));
 express.use(logger("dev"));
 express.use(Express.json());
 express.use(Express.urlencoded());

--- a/src/server/controller/activeEvents.ts
+++ b/src/server/controller/activeEvents.ts
@@ -22,13 +22,19 @@ export const activeEvents_get_all = async (req: Request, res: Response) => {
 }
 
 export const activeEvents_get_current = async (_: Request, res: Response) => {
-    const activeEvents = await ActiveEventService.getActiveEvent();
+    const activeEvents = await ActiveEventService.getOngoingActiveEvent();
 
     res.json(activeEvents);
 }
 
 export const activeEvents_get_incoming = async (_: Request, res: Response) => {
     const activeEvents = await ActiveEventService.getIncomingEvent();
+
+    res.json(activeEvents);
+}
+
+export const activeEvents_get_ongoing = async (_: Request, res: Response) => {
+    const activeEvents = await ActiveEventService.getOngoingActiveEvent();
 
     res.json(activeEvents);
 }

--- a/src/server/controller/authenticate.ts
+++ b/src/server/controller/authenticate.ts
@@ -6,7 +6,12 @@ import { OAUTH2_REDIRECT_URL, OAUTH2_REDIRECT_URL_SERVER } from "@config";
 import { requestOauth2, collectUserData } from "services/authenticate";
 import { UserService } from "@services/users";
 import SessionService from "@services/session";
+import client from "@bot";
+import { isDiscordUser } from "@models/DiscordUser";
 
+/**
+ * authenticate user through discord oauth2, returns session_key
+ */
 export async function authenticate_get(req: Request, res: Response){
   console.log("authenticate_get");
   const accessCode = req.query.code;
@@ -39,19 +44,9 @@ export async function authenticate_get(req: Request, res: Response){
   });
 }
 
-export async function authenticate_post(req: Request, res: Response){
-  if(req.body.SESSION_KEY === undefined)
-    throw new Error("no SESSION_KEY provided");
-
-  debug(`authenticating user with SESSION_KEY: ${req.body.SESSION_KEY}`);
-
-  const SESSION_KEY = req.body.SESSION_KEY;
-  const found = await SessionService.getSession(SESSION_KEY);
-
-  debug(`got sessionkey for user ${found.username}`);
-  res.json(found);
-}
-
+/**
+ * authenticate the user without needing a redirect to the browser, used only on postman testing
+ */
 export async function authenticate_server(req: Request, res: Response){
   const accessCode = req.query.code;
   
@@ -80,12 +75,29 @@ export async function authenticate_server(req: Request, res: Response){
   res.json({SESSION_KEY: resSession.id});
 }
 
+/**
+ * gets the user profile via the provided session key
+ */
 export async function getUserProfile(req: Request, res: Response){
-  if(!req.cookies.sessionid || typeof req.cookies.sessionid !== "string")
-    res.status(401).send({error: 401, message: "Unauthorized!"});
+  // this error should not be thrown since the sessionCheck middleware should have already checked this
+  if(req.user === undefined)
+    throw new Error("no session_key provided");
 
-  const sessionid = req.cookies.sessionid;
-  const session = await SessionService.getSession(sessionid);
-
-  res.json(session);
+  res.json(req.user);
 }
+
+/**
+ * gets discord profile of the user, based on user's session key
+ */
+export async function get_discord_profile(req: Request, res: Response){
+  // this error should not be thrown since the sessionCheck middleware should have already checked this
+  if(req.user === undefined)
+    throw new Error("no session_key provided");
+
+  const user = await client.users.fetch(req.user.id) as unknown;
+
+  if(isDiscordUser(user))
+    res.json(user);
+  else
+    throw new Error("Failed to fetch user");
+};

--- a/src/server/middlewares/sessionCheck.ts
+++ b/src/server/middlewares/sessionCheck.ts
@@ -1,21 +1,27 @@
 const debug = require("debug")("Server:sessionCheck");
 
+import { UserService } from "@services";
 import SessionService from "@services/session";
 import { NextFunction, Request, RequestHandler, Response } from "express";
 
 export function sessionCheck(): RequestHandler{
     return async (req: Request, res: Response, next: NextFunction) => {    
         // check if session is set
-        const sessionid = req.cookies.SESSION_KEY as unknown;
+        const sessionid = req.cookies.session_key as unknown;
 
         if(!sessionid)
-            debug("no sessionid found");
+            debug(`no sessionid found`);
         else
             debug(`sessionid found: ${sessionid}`);
 
         try{
-            if(typeof sessionid === "string")
-                req.user = await SessionService.getSession(sessionid);
+            if(typeof sessionid === "string"){
+                // ensures that no session-exclusive properties can be accessed
+                const session = await SessionService.getSession(sessionid);
+
+                // req user must be only be of User type
+                req.user = await UserService.getUser(session.user_id);
+            }
 
             next();
         }

--- a/src/server/routes/activeEvents.ts
+++ b/src/server/routes/activeEvents.ts
@@ -1,5 +1,5 @@
 import { RouterInterface } from "@library";
-import { activeEvents_get_all, activeEvents_get_by_id, activeEvents_get_incoming, activeEvents_post_add, activeEvents_post_delete, activeEvents_post_edit } from "server/controller/activeEvents";
+import { activeEvents_get_all, activeEvents_get_by_id, activeEvents_get_incoming, activeEvents_get_ongoing, activeEvents_post_add, activeEvents_post_delete, activeEvents_post_edit } from "server/controller/activeEvents";
 import upload from "server/multerConfig";
 
 const routes: RouterInterface[] = [
@@ -18,6 +18,12 @@ const routes: RouterInterface[] = [
     {
         path: "/activeEvents/incoming",
         handler: activeEvents_get_incoming,
+        method: "get",
+        accessType: "public",
+    },
+    {
+        path: "/activeEvents/ongoing",
+        handler: activeEvents_get_ongoing,
         method: "get",
         accessType: "public",
     },

--- a/src/server/routes/authenticate.ts
+++ b/src/server/routes/authenticate.ts
@@ -1,17 +1,11 @@
 import { RouterInterface } from "@library";
-import { authenticate_get, authenticate_post, authenticate_server, getUserProfile } from "server/controller/authenticate";
+import { authenticate_get, authenticate_server, get_discord_profile, getUserProfile } from "server/controller/authenticate";
 
 export const routes: RouterInterface[] = [
     {
         path: "/authenticate",
         handler: authenticate_get,
         method: "get",
-        accessType: "public",
-    },
-    {
-        path: "/authenticate",
-        handler: authenticate_post,
-        method: "post",
         accessType: "public",
     },
     {
@@ -23,6 +17,12 @@ export const routes: RouterInterface[] = [
     {
         path: "/profile",
         handler: getUserProfile,
+        method: "get",
+        accessType: "private",
+    },
+    {
+        path: "/profile/discord",
+        handler: get_discord_profile,
         method: "get",
         accessType: "private",
     }

--- a/src/services/activeEvent.ts
+++ b/src/services/activeEvent.ts
@@ -61,8 +61,8 @@ export class ActiveEventService {
         return Promise.all(res.map(ActiveEventService.translateImageToUrl));
     }
 
-    static async getActiveEvent(): Promise<ActiveEvent[]>{
-        const date = new Date().toISOString();
+    static async getOngoingActiveEvent(): Promise<ActiveEvent[]>{
+        const date = new Date().toLocaleString();
         const res = await ActiveEventService
             .activeEventManager
             .queryBuilder((query => query


### PR DESCRIPTION
- changed the policy from using SESSION_KEY in header  authorization to cookie-based authorization
- splits up the profile from database to discord's profile
- changed allActiveEvents name to getOngoingActiveEvents to avoid confusion
- removal /authenticate since it's redundant